### PR TITLE
Updated MailChimp SDK

### DIFF
--- a/src/htbox/htbox.csproj
+++ b/src/htbox/htbox.csproj
@@ -22,6 +22,8 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,8 +56,8 @@
     <Reference Include="Lucene.Net">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
-    <Reference Include="MailChimp">
-      <HintPath>..\..\packages\mcapi.net.1.3.1.3\lib\net40\MailChimp.dll</HintPath>
+    <Reference Include="MailChimp.Net, Version=4.2.1.0, Culture=neutral, PublicKeyToken=37d26d538413c581, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MailChimp.Net.V3.4.2.1\lib\net45\MailChimp.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="N2, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -81,6 +83,9 @@
     <Reference Include="N2.ReusableParts, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\N2CMS.Management.2.5.6.1\lib\N2.ReusableParts.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate">
       <HintPath>..\..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
@@ -111,9 +116,6 @@
     <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.0\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>

--- a/src/htbox/packages.config
+++ b/src/htbox/packages.config
@@ -5,7 +5,7 @@
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
-  <package id="mcapi.net" version="1.3.1.3" targetFramework="net45" />
+  <package id="MailChimp.Net.V3" version="4.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net45" />
@@ -22,7 +22,7 @@
   <package id="N2CMS.Config" version="1.3.14" targetFramework="net45" />
   <package id="N2CMS.Library" version="2.5.6.1" targetFramework="net45" />
   <package id="N2CMS.Management" version="2.5.6.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net45" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.0.3" targetFramework="net45" />


### PR DESCRIPTION
The old SDK was for MailChimp API v1.x. The updated SDK uses the most current version of the API (v3.x). Updated code to use the new SDK as well.